### PR TITLE
Addresses random device issue #44

### DIFF
--- a/cmake_modules/AllPythonBindings.cmake
+++ b/cmake_modules/AllPythonBindings.cmake
@@ -99,7 +99,6 @@ if(tests)
       set(PATH_STRING "${ADD_TO_PATH};$ENV{PATH}")
       STRING(REPLACE "\\;" ";" PATH_STRING "${PATH_STRING}")
       STRING(REPLACE ";" "\\;" PATH_STRING "${PATH_STRING}")
-      message(FATAL_ERROR "${ADD_TO_PATH}")
       set_tests_properties(python_${name} PROPERTIES ENVIRONMENT
                            "PATH=${PATH_STRING}")
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/cmake_modules/CheckCXX11Features.cmake
+++ b/cmake_modules/CheckCXX11Features.cmake
@@ -88,9 +88,14 @@ CXX11_CHECK_FEATURE("type_traits"         ""   HAS_CXX11_TYPETRAITS)
 CXX11_CHECK_FEATURE("trivial_type_traits" ""   HAS_CXX11_TRIVIALTYPETRAITS)
 CXX11_CHECK_FEATURE("noexcept"            ""   HAS_CXX11_NOEXCEPT)
 CXX11_CHECK_FEATURE("constexpr"           2235 HAS_CXX11_CONSTEXPR)
-CXX11_CHECK_FEATURE("random_device"       ""   HAS_CXX11_RANDOM_DEVICE)
 CXX11_CHECK_FEATURE("unique_ptr"          ""   HAS_CXX11_UNIQUE_PTR)
 CXX11_CHECK_FEATURE("shared_ptr"          ""   HAS_CXX11_SHARED_PTR)
+# MinGW has not implemented std::random_device fully yet. Unfortunately, this can only be detected
+# by running a program which tries to call std::random_device. However that generates an error that
+# is *not* caught by CMake's try_run. 
+if(NOT MSYS)
+  CXX11_CHECK_FEATURE("random_device"       ""   HAS_CXX11_RANDOM_DEVICE)
+endif(NOT MSYS)
 if(NOT (HAS_CXX11_AUTO 
         AND HAS_CXX11_LAMBDA 
         AND HAS_CXX11_STATIC_ASSERT 


### PR DESCRIPTION
- Closes #44, for now in any case
- Removes debugging stuff in cmake
- MinGW has not implemented std::random_device fully yet. Unfortunately,
  this can only be detected by running a program which tries to call
  std::random_device. However that generates an error that is _not_
  caught by CMake's try_run.
