### PR TITLE
Improve benchmark examples

### DIFF
--- a/exploration/fitAChR1.py
+++ b/exploration/fitAChR1.py
@@ -23,8 +23,8 @@ def dcprogslik(x):
 def printiter(theta):
     global iternum
     iternum += 1
-    lik = dcprogslik(theta)
-    if iternum % 10 == 0:
+    if iternum % 100 == 0:
+        lik = dcprogslik(theta)
         print("iteration # {0:d}; log-lik = {1:.6f}".format(iternum, -lik))
         print(np.exp(theta))
 
@@ -70,11 +70,14 @@ likelihood = Log10Likelihood(bursts, mec.kA, tres, tcrit)
 
 iternum = 0
 start = time.clock()
+start_wall = time.time()
 res = minimize(dcprogslik, np.log(theta), method='Nelder-Mead', callback=printiter,)
 t3 = time.clock() - start
+t3_wall = time.time() - start_wall
 print ("\n\n\nScyPy.minimize (Nelder-Mead) Fitting finished: %4d/%02d/%02d %02d:%02d:%02d\n"
     %time.localtime()[0:6])
-print ('time in ScyPy.minimize (Nelder-Mead)=', t3)
+print ('CPU time in ScyPy.minimize (Nelder-Mead)=', t3)
+print ('Wall clock time in ScyPy.minimize (Nelder-Mead)=', t3_wall)
 print ('xout', res.x)
 mec.theta_unsqueeze(np.exp(res.x))
 print ("\n Final rate constants:")

--- a/exploration/fitGlyR4.py
+++ b/exploration/fitGlyR4.py
@@ -92,13 +92,15 @@ iternum = 0
 def printiter(theta):
     global iternum
     iternum += 1
-    lik = dcprogslik(theta)
-    print("iteration # {0:d}; log-lik = {1:.6f}".format(iternum, -lik))
-    print(np.exp(theta))
+    if iternum % 100 == 0:
+        lik = dcprogslik(theta)
+        print("iteration # {0:d}; log-lik = {1:.6f}".format(iternum, -lik))
+        print(np.exp(theta))
 
 lik = dcprogslik(theta)
 print ("\nStarting likelihood (DCprogs)= {0:.6f}".format(-lik))
 start = time.clock()
+wallclock_start = time.time()
 success = False
 result = None
 while not success:
@@ -112,9 +114,11 @@ while not success:
         theta = result.x
         
 end = time.clock()
+wallclock_end = time.time()
 print ("\nDCPROGS Fitting finished: %4d/%02d/%02d %02d:%02d:%02d\n"
         %time.localtime()[0:6])
-print ('time in simplex=', end - start)
+print ('CPU time in simplex=', end - start)
+print ('Wallclock time in simplex=', wallclock_end - wallclock_start)
 print ('\n\nresult=')
 print (result)
 
@@ -125,5 +129,3 @@ mec.theta_unsqueeze(np.exp(result.x))
 print ("\n Final rate constants:")
 mec.printout(sys.stdout)
 print ('\n\n')
-
-

--- a/exploration/fitGlyRke4.py
+++ b/exploration/fitGlyRke4.py
@@ -89,14 +89,15 @@ iternum = 0
 def printiter(theta):
     global iternum
     iternum += 1
-    lik = dcprogslik(theta)
     if iternum % 100 == 0:
+        lik = dcprogslik(theta)
         print("iteration # {0:d}; log-lik = {1:.6f}".format(iternum, -lik))
         print(np.exp(theta))
 
 lik = dcprogslik(theta)
 print ("\nStarting likelihood = {0:.6f}".format(-lik))
 start = time.clock()
+wallclock_start = time.time()
 success = False
 result = None
 while not success:
@@ -110,9 +111,11 @@ while not success:
         theta = result.x
         
 end = time.clock()
+wallclock_end = time.time()
 print ("\nHJCFIT Fitting finished: %4d/%02d/%02d %02d:%02d:%02d\n"
         %time.localtime()[0:6])
-print ('time in simplex=', end - start)
+print ('CPU time in simplex=', end - start)
+print ('Wallclock time in simplex=', wallclock_end - wallclock_start)
 print ('\n\nresult=')
 print (result)
 


### PR DESCRIPTION
Also measure wall clock time with time.time which is accurate for multithread jobs

Only calc likelihood in callback for every 100 itterations to reduce overhead