### PR TITLE
Place time critical matrices on the stack. 

### DIFF
--- a/DCProgsConfig.h.in
+++ b/DCProgsConfig.h.in
@@ -152,5 +152,7 @@ namespace DCProgs {
 
   //! The quiet NaN value
   t_real static const quiet_nan = std::numeric_limits<t_real>::quiet_NaN();
+
+  t_uint static const dcprogs_stack_matrix = DCPROGS_STACK_MATRIX_MAX;
 }
 #endif

--- a/DCProgsConfig.h.in
+++ b/DCProgsConfig.h.in
@@ -112,7 +112,7 @@ namespace DCProgs {
   //! Types of real matrices across DCProgs.
   typedef Eigen::Matrix<t_real, ::Eigen::Dynamic, ::Eigen::Dynamic, 0, ::Eigen::Dynamic, ::Eigen::Dynamic> t_rmatrix;
   //! Types of real matrices across DCProgs guaranteed to be allocated on the stack. Max size DCPROGS_STACK_MATRIX_MAX by DCPROGS_STACK_MATRIX_MAX
-  typedef Eigen::Matrix<t_real, ::Eigen::Dynamic, ::Eigen::Dynamic, 0, DCPROGS_STACK_MATRIX_MAX, DCPROGS_STACK_MATRIX_MAX> t_srmatrix;
+  typedef Eigen::Matrix<t_real, ::Eigen::Dynamic, ::Eigen::Dynamic, 0, DCPROGS_STACK_MATRIX_MAX, DCPROGS_STACK_MATRIX_MAX> t_stack_rmatrix;
   //! Types of boolean matrices across DCProgs.
   typedef Eigen::Matrix<bool, ::Eigen::Dynamic, ::Eigen::Dynamic, 0, ::Eigen::Dynamic, ::Eigen::Dynamic> t_bmatrix;
   //! Types of initial state vectors across DCProgs.

--- a/documentation/source/api/cpp/typehierarchy.rst
+++ b/documentation/source/api/cpp/typehierarchy.rst
@@ -27,7 +27,7 @@ Eigen/Math types
 .. doxygentypedef:: DCProgs::t_bmatrix
 
 .. doxygentypedef:: DCProgs::t_rmatrix
-.. doxygentypedef:: DCProgs::t_srmatrix
+.. doxygentypedef:: DCProgs::t_stack_rmatrix
 .. doxygentypedef:: DCProgs::t_cmatrix
 
 .. doxygentypedef:: DCProgs::t_Bursts

--- a/likelihood/approx_survivor.h
+++ b/likelihood/approx_survivor.h
@@ -72,9 +72,9 @@ namespace DCProgs {
                       t_real _upperbound=quiet_nan );
 
       //! Open to close transitions 
-      t_rmatrix af(t_real _t) const { return asymptotes_af_->operator()(_t); }
+      t_srmatrix af(t_real _t) const { return asymptotes_af_->operator()(_t); }
       //! Close to open transitions
-      t_rmatrix fa(t_real _t) const { return asymptotes_fa_->operator()(_t); }
+      t_srmatrix fa(t_real _t) const { return asymptotes_fa_->operator()(_t); }
       //! Number of exponential components for af
       t_uint nb_af_components() const { return static_cast<t_uint>(asymptotes_af_->size()); }
       //! Number of exponential components for fa
@@ -111,4 +111,3 @@ namespace DCProgs {
   MSWINDOBE std::ostream& operator<<(std::ostream& _stream, ApproxSurvivor const &_self);
 }
 #endif 
-

--- a/likelihood/approx_survivor.h
+++ b/likelihood/approx_survivor.h
@@ -72,9 +72,9 @@ namespace DCProgs {
                       t_real _upperbound=quiet_nan );
 
       //! Open to close transitions 
-      t_srmatrix af(t_real _t) const { return asymptotes_af_->operator()(_t); }
+      t_stack_rmatrix af(t_real _t) const { return asymptotes_af_->operator()(_t); }
       //! Close to open transitions
-      t_srmatrix fa(t_real _t) const { return asymptotes_fa_->operator()(_t); }
+      t_stack_rmatrix fa(t_real _t) const { return asymptotes_fa_->operator()(_t); }
       //! Number of exponential components for af
       t_uint nb_af_components() const { return static_cast<t_uint>(asymptotes_af_->size()); }
       //! Number of exponential components for fa

--- a/likelihood/asymptotes.cc
+++ b/likelihood/asymptotes.cc
@@ -28,16 +28,16 @@
 
 namespace DCProgs {
 
-  t_srmatrix Asymptotes :: operator()(t_real _t) const {
+  t_stack_rmatrix Asymptotes :: operator()(t_real _t) const {
 
     t_MatricesAndRoots :: const_iterator i_first = matrices_and_roots_.begin();
     t_MatricesAndRoots :: const_iterator const i_end = matrices_and_roots_.end();
 
-    auto function = [_t](t_MatrixAndRoot const &_mat_and_root) -> t_srmatrix {
+    auto function = [_t](t_MatrixAndRoot const &_mat_and_root) -> t_stack_rmatrix {
       return std::get<0>(_mat_and_root) * std::exp(_t * std::get<1>(_mat_and_root));
     };
 
-    t_srmatrix result = function(*i_first);
+    t_stack_rmatrix result = function(*i_first);
     for(++i_first; i_first != i_end; ++i_first) result += function(*i_first);
     return result;
   }
@@ -50,9 +50,9 @@ namespace DCProgs {
     matrices_and_roots_.reserve(_roots.size());
     for(Root const & root: _roots) {
 
-      t_srmatrix const H(_equation.H(root.root));
-      t_srmatrix const derivative(_equation.s_derivative(root.root));
-      Eigen::JacobiSVD<t_srmatrix> svd(H - root.root * t_srmatrix::Identity(H.rows(), H.cols()),
+      t_stack_rmatrix const H(_equation.H(root.root));
+      t_stack_rmatrix const derivative(_equation.s_derivative(root.root));
+      Eigen::JacobiSVD<t_stack_rmatrix> svd(H - root.root * t_stack_rmatrix::Identity(H.rows(), H.cols()),
                                       Eigen::ComputeThinU|Eigen::ComputeThinV);
 
       t_rvector const abs_singval( svd.singularValues().array().abs() );
@@ -89,7 +89,7 @@ namespace DCProgs {
   }
 
   // Matrix with which to compute \f$H_{FA}\f$ for  the CHS vectors.
-  t_srmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
+  t_stack_rmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
                                           t_real _tau, t_real _tcrit ) {
 
     auto function = [&_asymptotes, &_tcrit, &_tau](t_int i) -> t_rmatrix {
@@ -98,7 +98,7 @@ namespace DCProgs {
       t_real const root = std::get<1>(mat_and_root);
       return -Ri * std::exp(root * (_tcrit - _tau)) / root;
     };
-    t_srmatrix result = function(0);
+    t_stack_rmatrix result = function(0);
     for(t_int i(1); i < _asymptotes.size(); ++i) result += function(i);
     return result;
   }

--- a/likelihood/asymptotes.cc
+++ b/likelihood/asymptotes.cc
@@ -46,8 +46,8 @@ namespace DCProgs {
   Asymptotes :: Asymptotes   (DeterminantEq const &_equation, std::vector<Root> const &_roots)
                            : matrices_and_roots_() {
 
+    verify_qmatrix(_equation.get_qmatrix());
     matrices_and_roots_.reserve(_roots.size());
-
     for(Root const & root: _roots) {
 
       t_srmatrix const H(_equation.H(root.root));
@@ -85,6 +85,16 @@ namespace DCProgs {
 
       // Finally, add to vector of matrices and roots
       matrices_and_roots_.emplace_back(std::move(Ri), root.root);
+    }
+  }
+
+  void Asymptotes :: verify_qmatrix(QMatrix const &_qmatrix) {
+    if (_qmatrix.matrix.cols() > dcprogs_stack_matrix) {
+      std::ostringstream _stream;
+      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
+              dcprogs_stack_matrix <<
+              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
+      throw errors::Domain(_stream.str());
     }
   }
 

--- a/likelihood/asymptotes.cc
+++ b/likelihood/asymptotes.cc
@@ -28,59 +28,59 @@
 
 namespace DCProgs {
 
-  t_rmatrix Asymptotes :: operator()(t_real _t) const {
+  t_srmatrix Asymptotes :: operator()(t_real _t) const {
 
     t_MatricesAndRoots :: const_iterator i_first = matrices_and_roots_.begin();
     t_MatricesAndRoots :: const_iterator const i_end = matrices_and_roots_.end();
 
-    auto function = [_t](t_MatrixAndRoot const &_mat_and_root) -> t_rmatrix {
+    auto function = [_t](t_MatrixAndRoot const &_mat_and_root) -> t_srmatrix {
       return std::get<0>(_mat_and_root) * std::exp(_t * std::get<1>(_mat_and_root));
     };
 
-    t_rmatrix result = function(*i_first);
-    for(++i_first; i_first != i_end; ++i_first) result += function(*i_first); 
+    t_srmatrix result = function(*i_first);
+    for(++i_first; i_first != i_end; ++i_first) result += function(*i_first);
     return result;
   }
 
 
-  Asymptotes :: Asymptotes   (DeterminantEq const &_equation, std::vector<Root> const &_roots) 
+  Asymptotes :: Asymptotes   (DeterminantEq const &_equation, std::vector<Root> const &_roots)
                            : matrices_and_roots_() {
 
     matrices_and_roots_.reserve(_roots.size());
 
     for(Root const & root: _roots) {
 
-      t_rmatrix const H(_equation.H(root.root));
-      t_rmatrix const derivative(_equation.s_derivative(root.root)); 
-      Eigen::JacobiSVD<t_rmatrix> svd(H - root.root * t_rmatrix::Identity(H.rows(), H.cols()), 
+      t_srmatrix const H(_equation.H(root.root));
+      t_srmatrix const derivative(_equation.s_derivative(root.root));
+      Eigen::JacobiSVD<t_srmatrix> svd(H - root.root * t_srmatrix::Identity(H.rows(), H.cols()),
                                       Eigen::ComputeThinU|Eigen::ComputeThinV);
 
       t_rvector const abs_singval( svd.singularValues().array().abs() );
 
-      if(static_cast<t_uint>(abs_singval.size()) < root.multiplicity) 
+      if(static_cast<t_uint>(abs_singval.size()) < root.multiplicity)
         throw errors::Mass("Requesting more roots than there are singular values.");
 
       // Figures out lowest singular values
       // To do this, creates a vector of indices that is partially sorted.
       t_int i(0);
-      std::vector<t_int> indices( abs_singval.size() ); 
+      std::vector<t_int> indices( abs_singval.size() );
       std::generate(indices.begin(), indices.end(), [&i]() { return i++; });
       auto comparison = [abs_singval](t_int a, t_int b) {
-        return abs_singval(a) < abs_singval(b); 
+        return abs_singval(a) < abs_singval(b);
       };
       std::partial_sort(indices.begin(), indices.begin() + root.multiplicity,
                         indices.end(), comparison);
 
       // Following is 2.29 from Colquhounm Hawkes, Srodzinski (1996)
       auto single_root_function = [&svd, &derivative, &H, &root](t_int _index) -> t_rmatrix { 
-         auto c_i = svd.matrixV().col(_index) / svd.matrixV().col(_index).sum() ; 
+         auto c_i = svd.matrixV().col(_index) / svd.matrixV().col(_index).sum() ;
          auto r_i = svd.matrixU().col(_index).transpose() / svd.matrixU().col(_index).sum();
          return c_i * r_i / (r_i * derivative * c_i);
-      }; 
+      };
       // Now loop over all degenerate roots.
       std::vector<t_int> :: const_iterator i_first = indices.begin();
       std::vector<t_int> :: const_iterator const i_end = i_first + root.multiplicity;
-      t_rmatrix Ri = single_root_function(*i_first);  
+      t_rmatrix Ri = single_root_function(*i_first);
       for(++i_first; i_first != i_end; ++i_first) Ri += single_root_function(*i_first);
 
       // Finally, add to vector of matrices and roots
@@ -89,7 +89,7 @@ namespace DCProgs {
   }
 
   // Matrix with which to compute \f$H_{FA}\f$ for  the CHS vectors.
-  t_rmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
+  t_srmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
                                           t_real _tau, t_real _tcrit ) {
 
     auto function = [&_asymptotes, &_tcrit, &_tau](t_int i) -> t_rmatrix {
@@ -98,7 +98,7 @@ namespace DCProgs {
       t_real const root = std::get<1>(mat_and_root);
       return -Ri * std::exp(root * (_tcrit - _tau)) / root;
     };
-    t_rmatrix result = function(0);
+    t_srmatrix result = function(0);
     for(t_int i(1); i < _asymptotes.size(); ++i) result += function(i);
     return result;
   }

--- a/likelihood/asymptotes.cc
+++ b/likelihood/asymptotes.cc
@@ -88,16 +88,6 @@ namespace DCProgs {
     }
   }
 
-  void Asymptotes :: verify_qmatrix(QMatrix const &_qmatrix) {
-    if (_qmatrix.matrix.cols() > dcprogs_stack_matrix) {
-      std::ostringstream _stream;
-      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
-              dcprogs_stack_matrix <<
-              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
-      throw errors::Domain(_stream.str());
-    }
-  }
-
   // Matrix with which to compute \f$H_{FA}\f$ for  the CHS vectors.
   t_srmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
                                           t_real _tau, t_real _tcrit ) {

--- a/likelihood/asymptotes.h
+++ b/likelihood/asymptotes.h
@@ -43,8 +43,6 @@ namespace DCProgs {
       //! \brief Container holding the parameters for each exponential
       typedef std::vector<t_MatrixAndRoot> t_MatricesAndRoots;
 
-      //! Constructor. 
-      Asymptotes(t_MatricesAndRoots const &_values ) : matrices_and_roots_(_values) {} 
       //! Creates functor from equation and roots.
       Asymptotes(DeterminantEq const &_equation, std::vector<Root> const &_roots);
 

--- a/likelihood/asymptotes.h
+++ b/likelihood/asymptotes.h
@@ -37,7 +37,7 @@ namespace DCProgs {
       //! \brief Holds a pair defining each exponential function.
       //! \details - The first item is the weigh (as an matrix) of the exponential.
       //! - The second item is the exponent of the exponential.
-      typedef std::pair<t_rmatrix, t_real> t_MatrixAndRoot;
+      typedef std::pair<t_srmatrix, t_real> t_MatrixAndRoot;
 
       //| \typedef  std::vector<t_MatrixAndRoot> t_MatricesAndRoots
       //! \brief Container holding the parameters for each exponential
@@ -52,7 +52,7 @@ namespace DCProgs {
       //! \details The \f$s_i\f$ are the roots. \f$R_i\f$ matrices are weighted
       //! projections of the eigenvectors corresponding to the roots:
       //! \f$R_i = \frac{c_i\times r_i}{r_i \cdot W'(s_i) \cdot c_i}\f$.
-      t_rmatrix operator()(t_real _t) const;
+      t_srmatrix operator()(t_real _t) const;
 
       //! Access to matrices and roots
       //! The matrices are \f$^AR_i = \frac{c_i\cdot r_i}{r_i \cdot W'(s_i) \cdot c_i}\f$, where
@@ -83,7 +83,7 @@ namespace DCProgs {
   //! \note This is somewhat outside the remit of Asymptotes, although the calculations are similar
   //!       for good reasons. In any case, we keep this function outside the class itself, so as to
   //!       not confuse the purpose of the class itself.
-  t_rmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
+  t_srmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
                                           t_real _tau, t_real _tcrit );
 }
 #endif 

--- a/likelihood/asymptotes.h
+++ b/likelihood/asymptotes.h
@@ -73,8 +73,6 @@ namespace DCProgs {
     protected:
       //! Holds the weight and the exponent of the exponential functions.
       t_MatricesAndRoots matrices_and_roots_;
-    private:
-      void verify_qmatrix(QMatrix const &_qmatrix);
   };
 
   //! \brief Partial computation of \f$H_{FA}\f$ for CHS vectors.

--- a/likelihood/asymptotes.h
+++ b/likelihood/asymptotes.h
@@ -73,6 +73,8 @@ namespace DCProgs {
     protected:
       //! Holds the weight and the exponent of the exponential functions.
       t_MatricesAndRoots matrices_and_roots_;
+    private:
+      void verify_qmatrix(QMatrix const &_qmatrix);
   };
 
   //! \brief Partial computation of \f$H_{FA}\f$ for CHS vectors.

--- a/likelihood/asymptotes.h
+++ b/likelihood/asymptotes.h
@@ -37,7 +37,7 @@ namespace DCProgs {
       //! \brief Holds a pair defining each exponential function.
       //! \details - The first item is the weigh (as an matrix) of the exponential.
       //! - The second item is the exponent of the exponential.
-      typedef std::pair<t_srmatrix, t_real> t_MatrixAndRoot;
+      typedef std::pair<t_stack_rmatrix, t_real> t_MatrixAndRoot;
 
       //| \typedef  std::vector<t_MatrixAndRoot> t_MatricesAndRoots
       //! \brief Container holding the parameters for each exponential
@@ -50,7 +50,7 @@ namespace DCProgs {
       //! \details The \f$s_i\f$ are the roots. \f$R_i\f$ matrices are weighted
       //! projections of the eigenvectors corresponding to the roots:
       //! \f$R_i = \frac{c_i\times r_i}{r_i \cdot W'(s_i) \cdot c_i}\f$.
-      t_srmatrix operator()(t_real _t) const;
+      t_stack_rmatrix operator()(t_real _t) const;
 
       //! Access to matrices and roots
       //! The matrices are \f$^AR_i = \frac{c_i\cdot r_i}{r_i \cdot W'(s_i) \cdot c_i}\f$, where
@@ -81,7 +81,7 @@ namespace DCProgs {
   //! \note This is somewhat outside the remit of Asymptotes, although the calculations are similar
   //!       for good reasons. In any case, we keep this function outside the class itself, so as to
   //!       not confuse the purpose of the class itself.
-  t_srmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
+  t_stack_rmatrix MSWINDOBE partial_CHS_matrix( Asymptotes const &_asymptotes,
                                           t_real _tau, t_real _tcrit );
 }
 #endif 

--- a/likelihood/exact_survivor.cc
+++ b/likelihood/exact_survivor.cc
@@ -79,16 +79,6 @@ namespace DCProgs {
     tau_ = _tau;
   }
 
-  void ExactSurvivor :: verify_qmatrix(QMatrix const &_qmatrix) {
-    if (_qmatrix.matrix.cols() > dcprogs_stack_matrix) {
-      std::ostringstream _stream;
-      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
-              dcprogs_stack_matrix <<
-              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
-      throw errors::Domain(_stream.str());
-    }
-  }
-
   ExactSurvivor :: RecursionInterface::RecursionInterface( QMatrix const & _qmatrix,
                                                            t_real _tau, bool _doAF ) {
                    

--- a/likelihood/exact_survivor.cc
+++ b/likelihood/exact_survivor.cc
@@ -80,7 +80,7 @@ namespace DCProgs {
   }
 
   void ExactSurvivor :: verify_qmatrix(QMatrix const &_qmatrix) {
-    if (_qmatrix.matrix.rows() > dcprogs_stack_matrix or _qmatrix.matrix.cols() > dcprogs_stack_matrix) {
+    if (_qmatrix.matrix.cols() > dcprogs_stack_matrix) {
       std::ostringstream _stream;
       _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
               dcprogs_stack_matrix <<

--- a/likelihood/exact_survivor.cc
+++ b/likelihood/exact_survivor.cc
@@ -86,7 +86,7 @@ namespace DCProgs {
     QMatrix const transitions = _doAF ? _qmatrix: _qmatrix.transpose();
 
     // Solves eigenvalue problem
-    Eigen::EigenSolver<t_srmatrix> eigsolver(transitions.matrix);
+    Eigen::EigenSolver<t_stack_rmatrix> eigsolver(transitions.matrix);
     if(eigsolver.info() != Eigen::Success) 
         throw errors::Mass("Could not solve eigenvalue problem.");
 
@@ -97,8 +97,8 @@ namespace DCProgs {
     eigenvalues_ = -eigsolver.eigenvalues().real();
 
     // Initializes recursion formula for m == l == 0
-    t_srmatrix const eigenvectors = eigsolver.eigenvectors().real();
-    t_srmatrix const eigenvectors_inv = eigsolver.eigenvectors().inverse().real();
+    t_stack_rmatrix const eigenvectors = eigsolver.eigenvectors().real();
+    t_stack_rmatrix const eigenvectors_inv = eigsolver.eigenvectors().inverse().real();
     for(t_rvector::Index i(0); i < eigenvalues_.size(); ++i) {
       auto left = eigenvectors.col(i).head(transitions.nopen);
       auto right = eigenvectors_inv.row(i).head(transitions.nopen);
@@ -106,7 +106,7 @@ namespace DCProgs {
     }
 
     // Computes all Di values
-    t_srmatrix const exponential_factor = (_tau * transitions.ff()).exp() * transitions.fa();
+    t_stack_rmatrix const exponential_factor = (_tau * transitions.ff()).exp() * transitions.fa();
     for(t_rvector::Index i(0); i < eigenvalues_.size(); ++i) {
       auto left = eigenvectors.col(i).head(transitions.nopen);
       auto right = eigenvectors_inv.row(i).tail(transitions.nshut());
@@ -138,7 +138,7 @@ namespace DCProgs {
     //! \details See Theorem below equation 3.12
     template<class T> 
       typename T::t_element B_im_of_t(T &_C, t_uint _i, t_uint _m, t_real _t) {
-        t_srmatrix result = _C(_i, _m, 0);
+        t_stack_rmatrix result = _C(_i, _m, 0);
         t_real t(_t);
         for(t_uint r(1); r <= _m; ++r, t *= _t) result += _C(_i, _m, r) * t;
         return result;
@@ -148,7 +148,7 @@ namespace DCProgs {
     template<class T> 
       typename T::t_element M_m_of_t(T &_C, t_uint _m, t_real _t) {
 
-        t_srmatrix result = B_im_of_t(_C, 0, _m, _t) * std::exp(-_C.get_eigvals(0)*_t);
+        t_stack_rmatrix result = B_im_of_t(_C, 0, _m, _t) * std::exp(-_C.get_eigvals(0)*_t);
         for(t_uint i(1); i < _C.nbeigvals(); ++i)
           result += B_im_of_t(_C, i, _m, _t) * std::exp(-_C.get_eigvals(i)*_t);
         return result;
@@ -160,7 +160,7 @@ namespace DCProgs {
       typename T::t_element R_of_t(T &_C, t_real _t, t_real _tau) {
 
         t_real current_t(_t);
-        t_srmatrix result = M_m_of_t(_C, 0, _t);
+        t_stack_rmatrix result = M_m_of_t(_C, 0, _t);
         t_uint m=1;
         
         for(current_t -= _tau; current_t > 0; current_t -= _tau, ++m)  {
@@ -172,35 +172,35 @@ namespace DCProgs {
 
   }
 
-  t_srmatrix ExactSurvivor :: af(t_real _t) const {
+  t_stack_rmatrix ExactSurvivor :: af(t_real _t) const {
     if(_t < 0e0) return recursion_af_->zero();
     return R_of_t(*recursion_af_, _t, tau_);
   }
-  t_srmatrix ExactSurvivor :: fa(t_real _t) const {
+  t_stack_rmatrix ExactSurvivor :: fa(t_real _t) const {
     if(_t < 0e0) return recursion_fa_->zero();
     return R_of_t(*recursion_fa_, _t, tau_);
   }
 
-  t_srmatrix ExactSurvivor :: recursion_af(t_uint _i, t_uint _m, t_uint _l) const {
+  t_stack_rmatrix ExactSurvivor :: recursion_af(t_uint _i, t_uint _m, t_uint _l) const {
     if(_i >= recursion_af_->nbeigvals())  
       throw errors::Index("i index should be smaller than the number of eigenvalues.");
     if(_l > _m) throw errors::Index("l index should be smaller than m index.");
     if(_m > 10) throw errors::Index("m index should be smaller than 10.");
     return  recursion_af_->operator()(_i, _m, _l);
   }
-  t_srmatrix ExactSurvivor :: recursion_fa(t_uint _i, t_uint _m, t_uint _l) const {
+  t_stack_rmatrix ExactSurvivor :: recursion_fa(t_uint _i, t_uint _m, t_uint _l) const {
     if(_i >= recursion_fa_->nbeigvals())  
       throw errors::Index("i index should be smaller than the number of eigenvalues.");
     if(_l > _m) throw errors::Index("l index should be smaller than m index.");
     if(_m > 10) throw errors::Index("m index should be smaller than 10.");
     return  recursion_fa_->operator()(_i, _m, _l);
   }
-  t_srmatrix ExactSurvivor :: D_af(t_uint _i) const {
+  t_stack_rmatrix ExactSurvivor :: D_af(t_uint _i) const {
     if(_i >= recursion_af_->nbeigvals())  
       throw errors::Index("i index should be smaller than the number of eigenvalues.");
     return  recursion_af_->getD(_i);
   }
-  t_srmatrix ExactSurvivor :: D_fa(t_uint _i) const {
+  t_stack_rmatrix ExactSurvivor :: D_fa(t_uint _i) const {
     if(_i >= recursion_fa_->nbeigvals())  
       throw errors::Index("i index should be smaller than the number of eigenvalues.");
     return  recursion_fa_->getD(_i);

--- a/likelihood/exact_survivor.cc
+++ b/likelihood/exact_survivor.cc
@@ -67,7 +67,7 @@ namespace DCProgs {
 
   void ExactSurvivor :: set(QMatrix const &_qmatrix, t_real _tau) {
     if(_tau < 0e0) throw errors::Domain("The resolution time tau cannot be negative.");
-
+    verify_qmatrix(_qmatrix);
     // Two step process. Otherwise, reset would catch any exception thrown. 
     RecursionInterface afinterface(_qmatrix, _tau, true);
     RecursionInterface fainterface(_qmatrix, _tau, false);

--- a/likelihood/exact_survivor.cc
+++ b/likelihood/exact_survivor.cc
@@ -79,6 +79,15 @@ namespace DCProgs {
     tau_ = _tau;
   }
 
+  void ExactSurvivor :: verify_qmatrix(QMatrix const &_qmatrix) {
+    if (_qmatrix.matrix.rows() > dcprogs_stack_matrix or _qmatrix.matrix.cols() > dcprogs_stack_matrix) {
+      std::ostringstream _stream;
+      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
+              dcprogs_stack_matrix <<
+              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
+      throw errors::Domain(_stream.str());
+    }
+  }
 
   ExactSurvivor :: RecursionInterface::RecursionInterface( QMatrix const & _qmatrix,
                                                            t_real _tau, bool _doAF ) {

--- a/likelihood/exact_survivor.h
+++ b/likelihood/exact_survivor.h
@@ -66,21 +66,21 @@ namespace DCProgs {
       void set(QMatrix const &_qmatrix, t_real _tau);
 
       //! Probability of no shut times detected between 0 and t.
-      t_srmatrix af(t_real t) const;
+      t_stack_rmatrix af(t_real t) const;
       //! Probability of no open times detected between 0 and t.
-      t_srmatrix fa(t_real t) const;
+      t_stack_rmatrix fa(t_real t) const;
 
       //! Gets the value of tau;
       t_real get_tau() const { return tau_; }
   
       //! Returns recursion matrix for af
-      t_srmatrix recursion_af(t_uint _i, t_uint _m, t_uint _l) const;
+      t_stack_rmatrix recursion_af(t_uint _i, t_uint _m, t_uint _l) const;
       //! Returns recursion matrix for af
-      t_srmatrix recursion_fa(t_uint _i, t_uint _m, t_uint _l) const;
+      t_stack_rmatrix recursion_fa(t_uint _i, t_uint _m, t_uint _l) const;
       //! Returns Di  matrix for af
-      t_srmatrix D_af(t_uint _i) const;
+      t_stack_rmatrix D_af(t_uint _i) const;
       //! Returns Di matrix for af
-      t_srmatrix D_fa(t_uint _i) const;
+      t_stack_rmatrix D_fa(t_uint _i) const;
       //! Returns eigenvalues for af matrix
       t_rvector eigenvalues_af() const;
       //! Returns eigenvalues for fa matrix
@@ -120,7 +120,7 @@ namespace DCProgs {
   
     public:
       //! Element on which to perform recursion.
-      typedef t_srmatrix t_element;
+      typedef t_stack_rmatrix t_element;
       //! Constructor. 
       //! \param[in] _qmatrix The transition state matrix for which to compute
       //!                     \f$^eR_{AF}(t\rightarrow\infty)\f$
@@ -147,7 +147,7 @@ namespace DCProgs {
       //! Reference to eigenvalues
       t_rvector const & eigenvalues() const { return eigenvalues_; }
       //! A null matrix of appropriate size
-      decltype(t_srmatrix::Zero(1,1)) zero() const { return t_srmatrix::Zero(nopen, nopen); };
+      decltype(t_stack_rmatrix::Zero(1,1)) zero() const { return t_stack_rmatrix::Zero(nopen, nopen); };
 
     protected:
   

--- a/likelihood/exact_survivor.h
+++ b/likelihood/exact_survivor.h
@@ -47,14 +47,17 @@ namespace DCProgs {
       //! Initializes exact survivor functor.
       //! \param[in] _qmatrix Partitioned matrix with open states in top left corner.
       //! \param[in] _tau Missed event cutoff time.
-      ExactSurvivor(QMatrix const &_qmatrix, t_real _tau) { set(_qmatrix, _tau); }
+      ExactSurvivor(QMatrix const &_qmatrix, t_real _tau) {
+        set(_qmatrix, _tau);
+        verify_qmatrix(_qmatrix);}
       //! Initializes exact survivor functor.
       //! \param[in] _qmatrix A transition matrix with open states in top left corner
       //! \param[in] _nopen Number of open states. 
       //! \param[in] _tau Missed event cutoff time.
       template<class T>
-        ExactSurvivor(Eigen::DenseBase<T> const &_qmatrix, t_uint _nopen, t_real _tau)
-          { set(QMatrix(_qmatrix, _nopen), _tau); }
+        ExactSurvivor(Eigen::DenseBase<T> const &_qmatrix, t_uint _nopen, t_real _tau) {
+          set(QMatrix(_qmatrix, _nopen), _tau);
+          verify_qmatrix(_qmatrix);}
       //! Move constructor
       ExactSurvivor   (ExactSurvivor &&_c) 
                     : recursion_af_(std::move(_c.recursion_af_)),
@@ -107,6 +110,8 @@ namespace DCProgs {
       t_RecursionPtr recursion_fa_;
       //! Max length of missed events.
       t_real tau_;
+    private:
+      void verify_qmatrix(QMatrix const &_qmatrix);
   };
 
 

--- a/likelihood/exact_survivor.h
+++ b/likelihood/exact_survivor.h
@@ -65,21 +65,21 @@ namespace DCProgs {
       void set(QMatrix const &_qmatrix, t_real _tau);
 
       //! Probability of no shut times detected between 0 and t.
-      t_rmatrix af(t_real t) const;
+      t_srmatrix af(t_real t) const;
       //! Probability of no open times detected between 0 and t.
-      t_rmatrix fa(t_real t) const;
+      t_srmatrix fa(t_real t) const;
 
       //! Gets the value of tau;
       t_real get_tau() const { return tau_; }
   
       //! Returns recursion matrix for af
-      t_rmatrix recursion_af(t_uint _i, t_uint _m, t_uint _l) const;
+      t_srmatrix recursion_af(t_uint _i, t_uint _m, t_uint _l) const;
       //! Returns recursion matrix for af
-      t_rmatrix recursion_fa(t_uint _i, t_uint _m, t_uint _l) const;
+      t_srmatrix recursion_fa(t_uint _i, t_uint _m, t_uint _l) const;
       //! Returns Di  matrix for af
-      t_rmatrix D_af(t_uint _i) const;
+      t_srmatrix D_af(t_uint _i) const;
       //! Returns Di matrix for af
-      t_rmatrix D_fa(t_uint _i) const;
+      t_srmatrix D_fa(t_uint _i) const;
       //! Returns eigenvalues for af matrix
       t_rvector eigenvalues_af() const;
       //! Returns eigenvalues for fa matrix
@@ -119,7 +119,7 @@ namespace DCProgs {
   
     public:
       //! Element on which to perform recursion.
-      typedef t_rmatrix t_element;
+      typedef t_srmatrix t_element;
       //! Constructor. 
       //! \param[in] _qmatrix The transition state matrix for which to compute
       //!                     \f$^eR_{AF}(t\rightarrow\infty)\f$
@@ -146,7 +146,7 @@ namespace DCProgs {
       //! Reference to eigenvalues
       t_rvector const & eigenvalues() const { return eigenvalues_; }
       //! A null matrix of appropriate size
-      decltype(t_rmatrix::Zero(1,1)) zero() const { return t_rmatrix::Zero(nopen, nopen); };
+      decltype(t_srmatrix::Zero(1,1)) zero() const { return t_srmatrix::Zero(nopen, nopen); };
 
     protected:
   
@@ -164,4 +164,3 @@ namespace DCProgs {
 }
 
 #endif 
-

--- a/likelihood/exact_survivor.h
+++ b/likelihood/exact_survivor.h
@@ -108,8 +108,6 @@ namespace DCProgs {
       t_RecursionPtr recursion_fa_;
       //! Max length of missed events.
       t_real tau_;
-    private:
-      void verify_qmatrix(QMatrix const &_qmatrix);
   };
 
 

--- a/likelihood/exact_survivor.h
+++ b/likelihood/exact_survivor.h
@@ -48,16 +48,14 @@ namespace DCProgs {
       //! \param[in] _qmatrix Partitioned matrix with open states in top left corner.
       //! \param[in] _tau Missed event cutoff time.
       ExactSurvivor(QMatrix const &_qmatrix, t_real _tau) {
-        set(_qmatrix, _tau);
-        verify_qmatrix(_qmatrix);}
+        set(_qmatrix, _tau);}
       //! Initializes exact survivor functor.
       //! \param[in] _qmatrix A transition matrix with open states in top left corner
       //! \param[in] _nopen Number of open states. 
       //! \param[in] _tau Missed event cutoff time.
       template<class T>
         ExactSurvivor(Eigen::DenseBase<T> const &_qmatrix, t_uint _nopen, t_real _tau) {
-          set(QMatrix(_qmatrix, _nopen), _tau);
-          verify_qmatrix(_qmatrix);}
+          set(QMatrix(_qmatrix, _nopen), _tau);}
       //! Move constructor
       ExactSurvivor   (ExactSurvivor &&_c) 
                     : recursion_af_(std::move(_c.recursion_af_)),

--- a/likelihood/likelihood.cc
+++ b/likelihood/likelihood.cc
@@ -77,7 +77,7 @@ namespace DCProgs {
     t_rvector final;
 
     if(eq_vector)
-        final = t_rmatrix::Ones(_matrix.nshut(),1);
+        final = t_rvector::Ones(_matrix.nshut(),1);
     else
         final = CHS_occupancies(eG, tcritical, false).transpose();
 

--- a/likelihood/likelihood.cc
+++ b/likelihood/likelihood.cc
@@ -63,8 +63,6 @@ namespace DCProgs {
   }
 
   t_real Log10Likelihood::operator()(QMatrix const &_matrix) const {
-    MissedEventsG const eG = MissedEventsG( _matrix, tau, nmax, xtol, rtol, itermax,
-                                            lower_bound, upper_bound );
     if (_matrix.matrix.rows() > dcprogs_stack_matrix or _matrix.matrix.cols() > dcprogs_stack_matrix) {
       std::ostringstream _stream;
       _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
@@ -72,6 +70,9 @@ namespace DCProgs {
               " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
       throw errors::Domain(_stream.str());
     }
+    MissedEventsG const eG = MissedEventsG( _matrix, tau, nmax, xtol, rtol, itermax,
+                                            lower_bound, upper_bound );
+
     bool const eq_vector = DCPROGS_ISNAN(tcritical) or tcritical <= 0;
 
     t_rvector final;

--- a/likelihood/likelihood.cc
+++ b/likelihood/likelihood.cc
@@ -65,6 +65,13 @@ namespace DCProgs {
   t_real Log10Likelihood::operator()(QMatrix const &_matrix) const {
     MissedEventsG const eG = MissedEventsG( _matrix, tau, nmax, xtol, rtol, itermax,
                                             lower_bound, upper_bound );
+    if (_matrix.matrix.rows() > dcprogs_stack_matrix or _matrix.matrix.cols() > dcprogs_stack_matrix) {
+      std::ostringstream _stream;
+      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
+              dcprogs_stack_matrix <<
+              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
+      throw errors::Domain(_stream.str());
+    }
     bool const eq_vector = DCPROGS_ISNAN(tcritical) or tcritical <= 0;
 
     t_rvector final;

--- a/likelihood/likelihood.cc
+++ b/likelihood/likelihood.cc
@@ -63,13 +63,7 @@ namespace DCProgs {
   }
 
   t_real Log10Likelihood::operator()(QMatrix const &_matrix) const {
-    if (_matrix.matrix.rows() > dcprogs_stack_matrix or _matrix.matrix.cols() > dcprogs_stack_matrix) {
-      std::ostringstream _stream;
-      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
-              dcprogs_stack_matrix <<
-              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
-      throw errors::Domain(_stream.str());
-    }
+    verify_qmatrix(_matrix);
     MissedEventsG const eG = MissedEventsG( _matrix, tau, nmax, xtol, rtol, itermax,
                                             lower_bound, upper_bound );
 
@@ -90,6 +84,7 @@ namespace DCProgs {
     return result;
   }
   t_rvector Log10Likelihood::vector(QMatrix const &_matrix) const {
+    verify_qmatrix(_matrix);
     MissedEventsG const eG = MissedEventsG( _matrix, tau, nmax, xtol, rtol, itermax,
                                             lower_bound, upper_bound );
     bool const eq_vector = DCPROGS_ISNAN(tcritical) or tcritical <= 0;

--- a/likelihood/missed_eventsG.h
+++ b/likelihood/missed_eventsG.h
@@ -111,19 +111,19 @@ namespace DCProgs {
                       fa_factor_(std::move(_c.fa_factor_)) {}
 
       //! Open to close transitions 
-      t_srmatrix af(t_real _t) const {
+      t_stack_rmatrix af(t_real _t) const {
         return survivor_af(_t - ExactSurvivor::get_tau()) * af_factor_; 
       }
       //! Close to open transitions
-      t_srmatrix fa(t_real _t) const {
+      t_stack_rmatrix fa(t_real _t) const {
         return survivor_fa(_t - ExactSurvivor::get_tau()) * fa_factor_; 
       }
       //! Probability of no shut times detected between 0 and t.
-      t_srmatrix survivor_af(t_real _t) const {
+      t_stack_rmatrix survivor_af(t_real _t) const {
         return _t > tmax_ ? ApproxSurvivor::af(_t): ExactSurvivor::af(_t);
       }
       //! Probability of no open times detected between 0 and t.
-      t_srmatrix survivor_fa(t_real _t) const {
+      t_stack_rmatrix survivor_fa(t_real _t) const {
         return _t > tmax_ ? ApproxSurvivor::fa(_t): ExactSurvivor::fa(_t);
       }
 
@@ -140,9 +140,9 @@ namespace DCProgs {
       t_real get_tmax() const { return tmax_; }
 
       //! \f$Q_{AF}e^{-Q_{FF}\tau} \f$
-      t_srmatrix const & get_af_factor() const { return af_factor_; }
+      t_stack_rmatrix const & get_af_factor() const { return af_factor_; }
       //! \f$Q_{FA}e^{-Q_{AA}\tau} \f$
-      t_srmatrix const & get_fa_factor() const { return fa_factor_; }
+      t_stack_rmatrix const & get_fa_factor() const { return fa_factor_; }
 
       //! Exact laplace of AF
       t_rmatrix laplace_af(t_real _s) const {
@@ -175,9 +175,9 @@ namespace DCProgs {
       //! there.
       t_real tmax_;
       //! \f$Q_{AF}e^{-Q_{FF}\tau} \f$
-      t_srmatrix af_factor_;
+      t_stack_rmatrix af_factor_;
       //! \f$Q_{FA}e^{-Q_{AA}\tau} \f$
-      t_srmatrix fa_factor_;
+      t_stack_rmatrix fa_factor_;
   };
 
   //! Dumps Missed-Events likelihood to stream

--- a/likelihood/missed_eventsG.h
+++ b/likelihood/missed_eventsG.h
@@ -111,19 +111,19 @@ namespace DCProgs {
                       fa_factor_(std::move(_c.fa_factor_)) {}
 
       //! Open to close transitions 
-      t_rmatrix af(t_real _t) const {
+      t_srmatrix af(t_real _t) const {
         return survivor_af(_t - ExactSurvivor::get_tau()) * af_factor_; 
       }
       //! Close to open transitions
-      t_rmatrix fa(t_real _t) const {
+      t_srmatrix fa(t_real _t) const {
         return survivor_fa(_t - ExactSurvivor::get_tau()) * fa_factor_; 
       }
       //! Probability of no shut times detected between 0 and t.
-      t_rmatrix survivor_af(t_real _t) const {
+      t_srmatrix survivor_af(t_real _t) const {
         return _t > tmax_ ? ApproxSurvivor::af(_t): ExactSurvivor::af(_t);
       }
       //! Probability of no open times detected between 0 and t.
-      t_rmatrix survivor_fa(t_real _t) const {
+      t_srmatrix survivor_fa(t_real _t) const {
         return _t > tmax_ ? ApproxSurvivor::fa(_t): ExactSurvivor::fa(_t);
       }
 
@@ -140,9 +140,9 @@ namespace DCProgs {
       t_real get_tmax() const { return tmax_; }
 
       //! \f$Q_{AF}e^{-Q_{FF}\tau} \f$
-      t_rmatrix const & get_af_factor() const { return af_factor_; }
+      t_srmatrix const & get_af_factor() const { return af_factor_; }
       //! \f$Q_{FA}e^{-Q_{AA}\tau} \f$
-      t_rmatrix const & get_fa_factor() const { return fa_factor_; }
+      t_srmatrix const & get_fa_factor() const { return fa_factor_; }
 
       //! Exact laplace of AF
       t_rmatrix laplace_af(t_real _s) const {
@@ -175,9 +175,9 @@ namespace DCProgs {
       //! there.
       t_real tmax_;
       //! \f$Q_{AF}e^{-Q_{FF}\tau} \f$
-      t_rmatrix af_factor_;
+      t_srmatrix af_factor_;
       //! \f$Q_{FA}e^{-Q_{AA}\tau} \f$
-      t_rmatrix fa_factor_;
+      t_srmatrix fa_factor_;
   };
 
   //! Dumps Missed-Events likelihood to stream
@@ -185,4 +185,3 @@ namespace DCProgs {
 }
 
 #endif 
-

--- a/likelihood/qmatrix.cc
+++ b/likelihood/qmatrix.cc
@@ -55,4 +55,14 @@ namespace DCProgs {
     for(std::string::size_type i(0); i < sstr.str().size(); ++i) _stream << '-';
     return _stream << "\n" << DCProgs::numpy_io(_mat.matrix) << "\n";
   }
+
+  void verify_qmatrix(QMatrix const &_qmatrix) {
+    if (_qmatrix.matrix.cols() > dcprogs_stack_matrix) {
+      std::ostringstream _stream;
+      _stream << "Maximum supported QMatrix size is " << dcprogs_stack_matrix << "x" <<
+              dcprogs_stack_matrix <<
+              " Please change in DCProgsConfig.h.in and recompile to support a larger QMatrix";
+      throw errors::Domain(_stream.str());
+    }
+  }
 }

--- a/likelihood/qmatrix.h
+++ b/likelihood/qmatrix.h
@@ -92,6 +92,8 @@ namespace DCProgs {
 
   //! Dumps object to stream.
   MSWINDOBE std::ostream & operator<< (std::ostream &_stream, QMatrix const &_mat);
+
+  void verify_qmatrix(QMatrix const &_qmatrix);
 }
 
 #endif

--- a/likelihood/qmatrix.h
+++ b/likelihood/qmatrix.h
@@ -93,6 +93,8 @@ namespace DCProgs {
   //! Dumps object to stream.
   MSWINDOBE std::ostream & operator<< (std::ostream &_stream, QMatrix const &_mat);
 
+  //! Verify that a QMatrix is not to large to be used in a stack allocated
+  //! likelihood, exact_survivor or asymptotes calculation.
   void verify_qmatrix(QMatrix const &_qmatrix);
 }
 

--- a/likelihood/tests/asymptotes.cc
+++ b/likelihood/tests/asymptotes.cc
@@ -71,6 +71,16 @@ TEST_P(TestAsymptotes, correct_size) {
   EXPECT_EQ(result.cols(), result.rows());
 }
 
+// Checks the size of the matrices is correct.
+TEST_F(TestAsymptotes, throws) {
+  std::vector<Root> roots;
+  roots.emplace_back(-17090.192769236815, 1);
+  t_rmatrix Q = t_rmatrix::Zero(dcprogs_stack_matrix+2, dcprogs_stack_matrix+2);
+  QMatrix qmatrix = QMatrix(Q, dcprogs_stack_matrix/2);
+  DeterminantEq equation(qmatrix, 1e-4);
+  EXPECT_THROW(Asymptotes asymptotes(equation, roots), errors::Domain);
+}
+
 // Checks that left and right apply leave matrix untouched
 TEST_P(TestAsymptotes, is_projection_matrix) {
 
@@ -126,4 +136,3 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/likelihood/tests/exact_survivor.cc
+++ b/likelihood/tests/exact_survivor.cc
@@ -126,6 +126,14 @@ TEST_F(ExactSurvivorTest, negative_times) {
   EXPECT_EQ(survivor.fa(-1e-5).cols(), 3);
 }
 
+// Makes sure that code throws if qmatrix is too large to fit the stack
+TEST_F(ExactSurvivorTest, exceeds_stack_throws) {
+  Q.resize(dcprogs_stack_matrix+1,dcprogs_stack_matrix+1);
+  QMatrix qmatrix(Q, dcprogs_stack_matrix/2);
+  EXPECT_THROW(ExactSurvivor survivor(qmatrix, 1e-4), errors::Domain);
+  EXPECT_THROW(ExactSurvivor survivor(Q, dcprogs_stack_matrix/2, 1e-4), errors::Domain);
+}
+
 // Compares recursive implementation to the expanded one in this file.
 TEST_F(ExactSurvivorTest, first_interval) {
   std::cout.precision(15);
@@ -302,4 +310,3 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/likelihood/tests/likelihood.cc
+++ b/likelihood/tests/likelihood.cc
@@ -174,8 +174,13 @@ TEST_F(TestLikelihood, odd_intervals) {
   EXPECT_THROW((*likelihood)(qmatrix), errors::Domain);
 }
 
+// Makes sure that code throws if qmatrix is too large to fit the stack
+TEST_F(TestLikelihood, exceeds_stack_throws) {
+  qmatrix.matrix.resize(dcprogs_stack_matrix+1,dcprogs_stack_matrix+1);
+  likelihood->bursts = t_Bursts(1, t_Burst(1, 1.5e-4) );
+  EXPECT_THROW((*likelihood)(qmatrix), errors::Domain);
+}
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
This significantly speeds up the single core performance of HJCFIT. For example I see an improvement of fitglyR4 from approx 380 seconds to 130 on my mac. Similarly the simple benchmark in https://github.com/jenshnielsen/HJCfit_benchmark goes from 17 sec to less than 6. 

This means limiting the number of elements in the matrices to less than 50. As I understand it all these matrices are of the size n_shut, n_open or n_open + n_shut. In practice I don't think this is an issue but we can change the size if needed. To protect against out of memory access the constructors for log10likelihood, exact_survivor and asymptotes checks the supplied qmatrix size. 

This naturally uses more memory but for example fitglyR4 still only uses 57 MB 