### PR TITLE
Fix clang segfault on OSX 10.11 with stack allocated eigen arrays

### DIFF
--- a/likelihood/exact_survivor.cc
+++ b/likelihood/exact_survivor.cc
@@ -69,11 +69,11 @@ namespace DCProgs {
     if(_tau < 0e0) throw errors::Domain("The resolution time tau cannot be negative.");
     verify_qmatrix(_qmatrix);
     // Two step process. Otherwise, reset would catch any exception thrown. 
-    RecursionInterface afinterface(_qmatrix, _tau, true);
-    RecursionInterface fainterface(_qmatrix, _tau, false);
-    recursion_af_.reset(new RecursionInterface(std::move(afinterface)));
+    RecursionInterface* afinterface = new RecursionInterface(_qmatrix, _tau, true);
+    RecursionInterface* fainterface = new RecursionInterface(_qmatrix, _tau, false);
+    recursion_af_.reset(afinterface);
     if(not recursion_af_.get()) throw errors::Runtime("Could not initialize unique_ptr");
-    recursion_fa_.reset(new RecursionInterface(std::move(fainterface)));
+    recursion_fa_.reset(fainterface);
     if(not recursion_fa_.get()) throw errors::Runtime("Could not initialize unique_ptr");
 
     tau_ = _tau;


### PR DESCRIPTION
Looks like a compiler bug. The clang segfaults when trying to move the RecursionInterface. More debugging reveals that this is due to the `std::map<t_key, t_element>`. Changing this and the matching iterator to be heap allocated also fixes the crash. 


```diff
       // Checks for existence in cache.
       t_key const key(_i, _m, _l);
-      std::map<t_key, t_element>::const_iterator const i_found = coeff_map_.find(key);
+      std::map<t_key, t_rmatrix>::const_iterator const i_found = coeff_map_.find(key);
       if(i_found != coeff_map_.end()) return i_found->second;

       // Otherwise compute it from recursion
diff --git a/likelihood/exact_survivor.h b/likelihood/exact_survivor.h
index 4b238fd..d3b9297 100644
--- a/likelihood/exact_survivor.h
+++ b/likelihood/exact_survivor.h
@@ -153,7 +153,7 @@ namespace DCProgs {
       //! Key of the map where coefficient matrices are stored.
       typedef std::tuple<t_uint, t_uint, t_uint> t_key;
       //! Map where coefficients are stored.
-      std::map<t_key, t_element> coeff_map_;
+      std::map<t_key, t_rmatrix> coeff_map_;
       //! D matrices (See equation 3.16)
       std::vector<t_element> dvalues_;
       //! Eigenvalues of the transition rate matrix.
```